### PR TITLE
Update name for North Macedonia

### DIFF
--- a/Localization/SwiftDGC/en.xcloc/Sources/SupportingFiles/en.lproj/Localizable.strings
+++ b/Localization/SwiftDGC/en.xcloc/Sources/SupportingFiles/en.lproj/Localizable.strings
@@ -277,7 +277,7 @@
 "country.LT" = "Lithuania";
 "country.LU" = "Luxembourg";
 "country.MO" = "Macao";
-"country.MK" = "Macedonia, the former Yugoslav Republic of";
+"country.MK" = "North Macedonia";
 "country.MG" = "Madagascar";
 "country.MW" = "Malawi";
 "country.MY" = "Malaysia";


### PR DESCRIPTION
In June 2018, Macedonia and Greece resolved the dispute with an agreement that the country should rename itself "Republic of North Macedonia", or "North Macedonia" for short. This renaming came into effect in February 2019.