### PR TITLE
To support iOS 15 and Avoid Crash in iOS 15. 

### DIFF
--- a/Sources/ViewControllers/Scan.swift
+++ b/Sources/ViewControllers/Scan.swift
@@ -227,7 +227,7 @@ extension ScanVC {
         for barcode in barcodes {
           guard
             let potentialQRCode = barcode as? VNBarcodeObservation,
-            [.Aztec, .QR, .DataMatrix].contains(potentialQRCode.symbology),
+            [.aztec, .qr, .dataMatrix].contains(potentialQRCode.symbology),
             potentialQRCode.confidence > 0.9
           else { return }
 


### PR DESCRIPTION
As per Vision Framework iOS

extension VNBarcodeSymbology {

    @available(macOS, introduced: 10.13, deprecated: 12.0, renamed: "aztec")
    @available(iOS, introduced: 11.0, deprecated: 15.0, renamed: "aztec")
    @available(tvOS, introduced: 11.0, deprecated: 15.0, renamed: "aztec")
    public static let Aztec: VNBarcodeSymbology
    
    
}

Aztec, QR,DataMatrix which are deprecated in iOS 15. so it is crashing with Xcode 13


In Scan.swift file,
processClassification method,
this line of code [.Aztec, .QR, .DataMatrix] is crashing.


It needs to be modified to as renamed names to avoid

[.aztec, .qr, .dataMatrix]
